### PR TITLE
Add clear guidance for structuring input fields in testsets

### DIFF
--- a/features/testsets.mdx
+++ b/features/testsets.mdx
@@ -38,6 +38,67 @@ Each Testset has a _schema_, which defines which fields a Testcase has, the type
 - <span className="text-green-500 font-bold">Expected fields</span> are expected or ideal outputs, which metrics compare your AI system's output to.
 - <span className="dark:text-gray-400 text-gray-600 font-bold">Metadata fields</span> are additional context for analysis, not used by evaluation or your system.
 
+#### Understanding Input Fields
+
+**Input fields** contain the actual data that gets sent to your AI system, workflow, or agent during testing. These should match exactly what your system expects to receive in production.
+
+Common patterns for structuring inputs:
+
+<Tabs>
+  <Tab title="Chatbot/LLM">
+    For conversational AI systems:
+    ```json
+    {
+      "user_message": "How do I reset my password?",
+      "conversation_history": [...],
+      "system_prompt": "You are a helpful assistant"
+    }
+    ```
+  </Tab>
+
+  <Tab title="AI Agent/Workflow">
+    For multi-step AI workflows or agents:
+    ```json
+    {
+      "task_description": "Analyze this document and extract key points",
+      "input_data": "Document content or reference",
+      "workflow_parameters": {
+        "mode": "detailed",
+        "output_format": "bullet_points"
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="API Endpoint">
+    For AI-powered API endpoints:
+    ```json
+    {
+      "request_body": {
+        "query": "Find similar products",
+        "filters": {"category": "electronics"}
+      },
+      "headers": {"api_key": "test_key"}
+    }
+    ```
+  </Tab>
+
+  <Tab title="Document Processing">
+    For document analysis systems:
+    ```json
+    {
+      "document_content": "Full text or path to document",
+      "extraction_query": "What are the payment terms?",
+      "document_type": "contract"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Tip>
+Your input fields should mirror your production system's interface. If your system expects a single prompt string, use a single string field. If it expects structured JSON with multiple parameters, reflect that structure in your schema.
+</Tip>
+
 You can update the schema of a Testset by clicking the **"Edit Schema"** button in the Testset actions menu.
 
 This allows you to add or remove fields, modify field types, and update field descriptions. Existing Testcases are not modified, but are validated against the new schema.
@@ -103,10 +164,86 @@ For example, here's a field mapping for the customer support schema above:
 ```json
 {
   "inputs": ["userQuery", "context"],
-  "expected": ["ideal", "expectedSentiment"], 
+  "expected": ["ideal", "expectedSentiment"],
   "metadata": ["difficulty"]
 }
 ```
+
+### Understanding Input Fields
+
+<Tip>
+**Quick tip**: Your input fields should match what goes INTO your AI system. Think about:
+- What do users type into your UI?
+- What data does your API receive?
+- What would a user or another system send to trigger your workflow?
+
+If you're unsure, ask an engineer on your team: "What JSON/data do we send to our AI system?"
+</Tip>
+
+#### Simple Examples
+
+**Basic Chatbot**
+```json
+{
+  "properties": {
+    "user_message": {
+      "type": "string",
+      "description": "What the user types in the chat box"
+    },
+    "expected_response": {
+      "type": "string",
+      "description": "What the bot should say back"
+    }
+  }
+}
+```
+Field mapping: `"inputs": ["user_message"], "expected": ["expected_response"]`
+
+**Document Q&A System**
+```json
+{
+  "properties": {
+    "question": {
+      "type": "string",
+      "description": "The question about the document"
+    },
+    "document": {
+      "type": "string",
+      "description": "The document text to search through"
+    },
+    "expected_answer": {
+      "type": "string",
+      "description": "The correct answer from the document"
+    }
+  }
+}
+```
+Field mapping: `"inputs": ["question", "document"], "expected": ["expected_answer"]`
+
+**AI Workflow/Agent**
+```json
+{
+  "properties": {
+    "task": {
+      "type": "string",
+      "description": "What you want the AI agent to do"
+    },
+    "input_data": {
+      "type": "string",
+      "description": "Any data the agent needs to complete the task"
+    },
+    "expected_output": {
+      "type": "string",
+      "description": "What the agent should produce"
+    }
+  }
+}
+```
+Field mapping: `"inputs": ["task", "input_data"], "expected": ["expected_output"]`
+
+<Note>
+The key is matching your test inputs to your actual system. If your system takes a single text field, use a single text field. If it takes multiple parameters, include those as separate fields.
+</Note>
 
 ## Create and edit Testcases
 


### PR DESCRIPTION
## Summary
- Adds practical guidance to help users understand how to structure input fields in their testsets
- Addresses user confusion about what "input fields" means for their AI systems

## Changes
- Added a helpful tip box explaining that input fields = what goes INTO their AI system
- Included guiding questions: "What do users type into your UI?" / "What data does your API receive?"
- Added three simple, clear examples with flat schemas:
  - Basic Chatbot
  - Document Q&A System
  - AI Workflow/Agent
- Provided actionable advice: "If unsure, ask an engineer on your team"

## Context
A user was confused about how to structure inputs for their testset. The existing documentation didn't clearly explain that input fields should match exactly what their AI system/workflow receives in production. This update makes it much clearer and more practical.