### PR TITLE
Improve schema examples with tabbed format

### DIFF
--- a/features/testsets.mdx
+++ b/features/testsets.mdx
@@ -180,85 +180,90 @@ Your input fields should mirror your production system's interface. If your syst
 
 The following examples show complete testcase schemas with both input and expected fields. The field mapping below each schema identifies which fields are inputs vs expected outputs.
 
-**Basic Chatbot**
-```json
-{
-  "type": "object",
-  "properties": {
-    "user_message": {
-      "type": "string",
-      "description": "What the user types in the chat box"
-    },
-    "expected_response": {
-      "type": "string",
-      "description": "What the bot should say back"
+<Tabs>
+  <Tab title="Basic Chatbot">
+    ```json
+    {
+      "type": "object",
+      "properties": {
+        "user_message": {
+          "type": "string",
+          "description": "What the user types in the chat box"
+        },
+        "expected_response": {
+          "type": "string",
+          "description": "What the bot should say back"
+        }
+      }
     }
-  }
-}
-```
-Field mapping:
-```json
-{
-  "inputs": ["user_message"],
-  "expected": ["expected_response"]
-}
-```
+    ```
+    Field mapping:
+    ```json
+    {
+      "inputs": ["user_message"],
+      "expected": ["expected_response"]
+    }
+    ```
+  </Tab>
 
-**Document Q&A System**
-```json
-{
-  "type": "object",
-  "properties": {
-    "question": {
-      "type": "string",
-      "description": "The question about the document"
-    },
-    "document": {
-      "type": "string",
-      "description": "The document text to search through"
-    },
-    "expected_answer": {
-      "type": "string",
-      "description": "The correct answer from the document"
+  <Tab title="Document Q&A">
+    ```json
+    {
+      "type": "object",
+      "properties": {
+        "question": {
+          "type": "string",
+          "description": "The question about the document"
+        },
+        "document": {
+          "type": "string",
+          "description": "The document text to search through"
+        },
+        "expected_answer": {
+          "type": "string",
+          "description": "The correct answer from the document"
+        }
+      }
     }
-  }
-}
-```
-Field mapping:
-```json
-{
-  "inputs": ["question", "document"],
-  "expected": ["expected_answer"]
-}
-```
+    ```
+    Field mapping:
+    ```json
+    {
+      "inputs": ["question", "document"],
+      "expected": ["expected_answer"]
+    }
+    ```
+  </Tab>
 
-**AI Workflow/Agent**
-```json
-{
-  "type": "object",
-  "properties": {
-    "task_description": {
-      "type": "string",
-      "description": "What you want the AI agent to do"
-    },
-    "input_data": {
-      "type": "string",
-      "description": "Any data the agent needs to complete the task"
-    },
-    "expected_output": {
-      "type": "string",
-      "description": "What the agent should produce"
+  <Tab title="AI Workflow/Agent">
+    ```json
+    {
+      "type": "object",
+      "properties": {
+        "task_description": {
+          "type": "string",
+          "description": "What you want the AI agent to do"
+        },
+        "input_data": {
+          "type": "string",
+          "description": "Any data the agent needs to complete the task"
+        },
+        "expected_output": {
+          "type": "string",
+          "description": "What the agent should produce"
+        }
+      }
     }
-  }
-}
-```
-Field mapping:
-```json
-{
-  "inputs": ["task_description", "input_data"],
-  "expected": ["expected_output"]
-}
-```
+    ```
+    Field mapping:
+    ```json
+    {
+      "inputs": ["task_description", "input_data"],
+      "expected": ["expected_output"]
+    }
+    ```
+  </Tab>
+</Tabs>
 
 <Note>
 The key is matching your test inputs to your actual system. If your system takes a single text field, use a single text field. If it takes multiple parameters, include those as separate fields.


### PR DESCRIPTION
## Summary
Converts the simple testcase schema examples to use the Tabs component for better organization and consistency.

## Changes
- Changed simple testcase schema examples from individual sections to tabbed format
- Now consistent with the "Common patterns for structuring inputs" section above
- Improves readability and makes it easier to navigate between different example types

## Benefits
- Better visual organization
- Consistent UI patterns throughout the documentation
- Easier to compare different schema approaches
- More compact presentation of multiple examples