### PR TITLE
docs(tracing): document OTEL_LOG_* env vars for Claude Agent SDK

### DIFF
--- a/features/sdk-tracing.mdx
+++ b/features/sdk-tracing.mdx
@@ -53,6 +53,9 @@ Choose any [instrumentation method](/features/tracing#instrumentation-methods). 
 export BETA_TRACING_ENDPOINT="https://tracing.scorecard.io/otel"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <your-scorecard-api-key>"
 export ENABLE_BETA_TRACING_DETAILED=1
+export OTEL_LOG_USER_PROMPTS=1
+export OTEL_LOG_TOOL_DETAILS=1
+export OTEL_LOG_TOOL_CONTENT=1
 export OTEL_RESOURCE_ATTRIBUTES="scorecard.project_id=<your-project-id>"
 ```
 
@@ -90,6 +93,9 @@ openai = wrap(OpenAI(), {"project_id": "YOUR_PROJECT_ID"})
             ENABLE_BETA_TRACING_DETAILED: '1',
             BETA_TRACING_ENDPOINT: 'https://tracing.scorecard.io/otel',
             OTEL_EXPORTER_OTLP_HEADERS: `Authorization=Bearer ${process.env.SCORECARD_API_KEY}`,
+            OTEL_LOG_USER_PROMPTS: '1',
+            OTEL_LOG_TOOL_DETAILS: '1',
+            OTEL_LOG_TOOL_CONTENT: '1',
             OTEL_RESOURCE_ATTRIBUTES: `scorecard.otel_link_id=${options!.otelLinkId},scorecard.project_id=${PROJECT_ID}`,
           },
         },
@@ -130,6 +136,9 @@ openai = wrap(OpenAI(), {"project_id": "YOUR_PROJECT_ID"})
                     "ENABLE_BETA_TRACING_DETAILED": "1",
                     "BETA_TRACING_ENDPOINT": "https://tracing.scorecard.io/otel",
                     "OTEL_EXPORTER_OTLP_HEADERS": f"Authorization=Bearer {os.environ['SCORECARD_API_KEY']}",
+                    "OTEL_LOG_USER_PROMPTS": "1",
+                    "OTEL_LOG_TOOL_DETAILS": "1",
+                    "OTEL_LOG_TOOL_CONTENT": "1",
                     "OTEL_RESOURCE_ATTRIBUTES": f"scorecard.otel_link_id={otel_link_id},scorecard.project_id={PROJECT_ID}",
                 }),
             ):

--- a/intro/claude-agent-sdk-tracing.mdx
+++ b/intro/claude-agent-sdk-tracing.mdx
@@ -24,6 +24,9 @@ This quickstart shows how to send traces from your Claude Agent SDK (Python v0.1
     export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <your_scorecard_api_key>"
     export ENABLE_BETA_TRACING_DETAILED=1
     export BETA_TRACING_ENDPOINT="https://tracing.scorecard.io/otel"
+    export OTEL_LOG_USER_PROMPTS=1
+    export OTEL_LOG_TOOL_DETAILS=1
+    export OTEL_LOG_TOOL_CONTENT=1
     ```
 
     <Note>
@@ -216,6 +219,9 @@ Set once per process, attached to every span.
 | `OTEL_EXPORTER_OTLP_HEADERS` | Yes | Authentication header: `Authorization=Bearer <scorecard_api_key>` |
 | `ENABLE_BETA_TRACING_DETAILED` | Yes | Set to `1` to enable detailed tracing |
 | `BETA_TRACING_ENDPOINT` | Yes | OTLP endpoint URL (use `https://tracing.scorecard.io/otel` for Scorecard) |
+| `OTEL_LOG_USER_PROMPTS` | Yes | Set to `1` to include user prompt content in spans |
+| `OTEL_LOG_TOOL_DETAILS` | Yes | Set to `1` to include tool names and input parameters in spans |
+| `OTEL_LOG_TOOL_CONTENT` | Yes | Set to `1` to include tool result content in spans |
 | `OTEL_RESOURCE_ATTRIBUTES` | No | Set `scorecard.project_id=<id>` to target a specific project (defaults to oldest project) |
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- Add `OTEL_LOG_USER_PROMPTS`, `OTEL_LOG_TOOL_DETAILS`, and `OTEL_LOG_TOOL_CONTENT` to the Claude Agent SDK tracing quickstart (bash setup block + env vars reference table).
- Add the same three vars to the SDK + Tracing setup page, including the bash block and the inline `env` objects in both the TypeScript and Python `runAndEvaluate` examples.

## Test plan
- [ ] `npx mintlify dev` and visually verify both pages render correctly
- [ ] `npx mintlify broken-links`